### PR TITLE
Use alpine base image for reduced image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.10.3
+FROM node:6.10.3-alpine
 
 ADD . /app
 WORKDIR /app


### PR DESCRIPTION
### Purpose
To reduce the size of the final image use Alpine linux. This also makes the build time faster as the base image to pull is a lot smaller.

### Notes
Size reduction for `0.0.12` is from 291MB to 48MB.